### PR TITLE
Adding .view property to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ class ViewController: UIViewController {
 
         let finalPix: PIX = blurPix
         finalPix.view.frame = view.bounds
-        view.addSubview(finalPix)
+        view.addSubview(finalPix.view)
         
     }
     


### PR DESCRIPTION
The `PIX` type is not a UIView and therefore can't be added as a subview. I believe that's what `.view` is there for 👍